### PR TITLE
Correcting the name of the container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ Docker (Linux only — host network mode required for WOL)
   ```bash
   docker run --rm --network host \
     -v ./coordinator_config.toml:/config/coordinator_config.toml:ro \
-    ghcr.io/9SMTM6/shuthost:latest
+    ghcr.io/9smtm6/shuthost/shuthost-coordinator:latest
   ```
 - docker-compose example:
   ```yaml
   version: "3.8"
   services:
     shuthost:
-      image: ghcr.io/9SMTM6/shuthost:latest
+      image: ghcr.io/9smtm6/shuthost/shuthost-coordinator:latest
       network_mode: "host"      # required for WOL
       restart: unless-stopped
       volumes:


### PR DESCRIPTION
The name of the container was incorrect and the path wasn't accepted by the repository.

ghcr.io/9smtm6/shuthost/shuthost-coordinator