### PR TITLE
Depend on host actor, fix notification issue

### DIFF
--- a/coordinator/src/app/db.rs
+++ b/coordinator/src/app/db.rs
@@ -14,7 +14,7 @@ use shuthost_common::protocol::{InitSystem, OsType};
 use sqlx::{Sqlite, SqlitePool, migrate::MigrateDatabase as _};
 use tracing::warn;
 
-use crate::app::{LeaseMapRaw, LeaseSource};
+use crate::app::{LeaseMap, LeaseSource};
 
 /// Database connection pool type alias.
 // This lint seems to have false negatives with pub(crate)
@@ -241,7 +241,7 @@ pub(crate) async fn delete_host_ip_override(pool: &DbPool, hostname: &str) -> ey
 ///
 /// Returns an error if the database query fails.
 #[tracing::instrument(skip(pool, leases), err)]
-pub(crate) async fn load_leases(pool: &DbPool, leases: &mut LeaseMapRaw) -> eyre::Result<()> {
+pub(crate) async fn load_leases(pool: &DbPool, leases: &mut LeaseMap) -> eyre::Result<()> {
     // Clear existing leases
     leases.clear();
 
@@ -1009,7 +1009,7 @@ mod tests {
     #[tokio::test]
     async fn add_and_load_leases() {
         let pool = setup_test_db().await.unwrap();
-        let mut leases: LeaseMapRaw = HashMap::new();
+        let mut leases: LeaseMap = HashMap::new();
 
         // Initially empty
         load_leases(&pool, &mut leases).await.unwrap();
@@ -1040,7 +1040,7 @@ mod tests {
     #[tokio::test]
     async fn remove_lease_works() {
         let pool = setup_test_db().await.unwrap();
-        let mut leases: LeaseMapRaw = HashMap::new();
+        let mut leases: LeaseMap = HashMap::new();
 
         // Add leases
         add_lease(&pool, "host1", &LeaseSource::WebInterface)
@@ -1066,7 +1066,7 @@ mod tests {
     #[tokio::test]
     async fn remove_client_leases_works() {
         let pool = setup_test_db().await.unwrap();
-        let mut leases: LeaseMapRaw = HashMap::new();
+        let mut leases: LeaseMap = HashMap::new();
 
         // Add client leases
         add_lease(&pool, "host1", &LeaseSource::Client("client1".to_string()))
@@ -1092,7 +1092,7 @@ mod tests {
     #[tokio::test]
     async fn duplicate_leases_ignored() {
         let pool = setup_test_db().await.unwrap();
-        let mut leases: LeaseMapRaw = HashMap::new();
+        let mut leases: LeaseMap = HashMap::new();
 
         // Add same lease twice
         add_lease(&pool, "host1", &LeaseSource::WebInterface)

--- a/coordinator/src/app/host_actor.rs
+++ b/coordinator/src/app/host_actor.rs
@@ -46,23 +46,19 @@ pub(crate) enum TransitionResult {
 ///
 /// Subscribers can use this stream to react to transitions in a single, ordered
 /// place rather than watching multiple independent channels.
-#[expect(dead_code)]
 #[derive(Debug, Clone)]
-pub(crate) enum HostEvent {
+pub(crate) enum HostEventType {
     /// A host's visible [`HostState`] changed.
-    StateChanged {
-        host: String,
-        from: HostState,
-        to: HostState,
-        /// Wall-clock instant of the change (from the actor's perspective).
-        at: Instant,
-    },
+    StateChanged { from: HostState, to: HostState },
     /// The lease set for a host changed.
-    LeaseChanged {
-        host: String,
-        leases: LeaseSources,
-        at: Instant,
-    },
+    LeaseChanged { leases: LeaseSources },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FullHostEvent {
+    pub(crate) host: String,
+    pub(crate) at: Instant,
+    pub(crate) event: HostEventType,
 }
 
 // ---------------------------------------------------------------------------
@@ -103,7 +99,7 @@ pub(crate) enum HostCmd {
     },
 
     /// The lease set for `host` changed; the actor re-emits it as a
-    /// [`HostEvent::LeaseChanged`] so all consumers can use a single stream.
+    /// [`HostEventType::LeaseChanged`] so all consumers can use a single stream.
     LeaseChanged { host: String, leases: LeaseSources },
 }
 
@@ -120,7 +116,7 @@ struct HostActor {
     /// Watch channel – published to on every state change.
     status_tx: Arc<watch::Sender<Arc<HostStatus>>>,
     /// Broadcast channel – events emitted on state & lease changes.
-    event_tx: Arc<broadcast::Sender<HostEvent>>,
+    event_tx: Arc<broadcast::Sender<FullHostEvent>>,
 }
 
 impl HostActor {
@@ -141,11 +137,13 @@ impl HostActor {
         drop(self.status_tx.send_replace(Arc::new(snapshot)));
 
         // Emit a typed event.
-        drop(self.event_tx.send(HostEvent::StateChanged {
+        drop(self.event_tx.send(FullHostEvent {
             host: host.to_string(),
-            from: old,
-            to: new_state,
             at: Instant::now(),
+            event: HostEventType::StateChanged {
+                from: old,
+                to: new_state,
+            },
         }));
     }
 
@@ -226,10 +224,10 @@ impl HostActor {
             }
 
             HostCmd::LeaseChanged { host, leases } => {
-                drop(self.event_tx.send(HostEvent::LeaseChanged {
+                drop(self.event_tx.send(FullHostEvent {
                     host,
-                    leases,
                     at: Instant::now(),
+                    event: HostEventType::LeaseChanged { leases },
                 }));
             }
         }
@@ -257,7 +255,7 @@ pub(crate) struct HostActorHandle {
     /// Held so callers can call `.subscribe()` / `.borrow()` / `.send_if_modified()`.
     pub(crate) status_tx: Arc<watch::Sender<Arc<HostStatus>>>,
     /// Held so callers can call `.subscribe()` to receive events.
-    event_tx: Arc<broadcast::Sender<HostEvent>>,
+    event_tx: Arc<broadcast::Sender<FullHostEvent>>,
 }
 
 impl HostActorHandle {
@@ -387,8 +385,8 @@ impl HostActorHandle {
         self.status_tx.subscribe()
     }
 
-    /// Subscribe to the typed [`HostEvent`] stream.
-    pub(crate) fn subscribe_events(&self) -> broadcast::Receiver<HostEvent> {
+    /// Subscribe to the typed [`FullHostEvent`] stream.
+    pub(crate) fn subscribe_events(&self) -> broadcast::Receiver<FullHostEvent> {
         self.event_tx.subscribe()
     }
 }
@@ -602,13 +600,13 @@ mod tests {
         });
 
         let ev = ev_rx.try_recv().expect("event should be available");
-        match ev {
-            HostEvent::StateChanged { host, from, to, .. } => {
-                assert_eq!(host, "srv");
+        match ev.event {
+            HostEventType::StateChanged { from, to } => {
+                assert_eq!(ev.host, "srv");
                 assert_eq!(from, HostState::Offline);
                 assert_eq!(to, HostState::Waking);
             }
-            HostEvent::LeaseChanged { .. } => panic!("unexpected event"),
+            HostEventType::LeaseChanged { .. } => panic!("unexpected event"),
         }
     }
 
@@ -624,16 +622,12 @@ mod tests {
         });
 
         let ev = ev_rx.try_recv().expect("event should be available");
-        match ev {
-            HostEvent::LeaseChanged {
-                host,
-                leases: got_leases,
-                ..
-            } => {
-                assert_eq!(host, "srv");
+        match ev.event {
+            HostEventType::LeaseChanged { leases: got_leases } => {
+                assert_eq!(ev.host, "srv");
                 assert_eq!(got_leases, leases);
             }
-            HostEvent::StateChanged { .. } => panic!("unexpected event"),
+            HostEventType::StateChanged { .. } => panic!("unexpected event"),
         }
     }
 

--- a/coordinator/src/app/host_actor.rs
+++ b/coordinator/src/app/host_actor.rs
@@ -21,7 +21,7 @@ use tokio::{
 use tracing::{debug, warn};
 
 use crate::app::{
-    host_control::LeaseSources,
+    host_control::{LeaseMap, LeaseSources},
     state::{HostState, OperationKind},
 };
 
@@ -54,9 +54,22 @@ pub(crate) enum TransitionResult {
 #[derive(Debug, Clone)]
 pub(crate) enum HostEventType {
     /// A host's visible [`HostState`] changed.
-    StateChanged { from: HostState, to: HostState },
+    ///
+    /// `coordinator_initiated` is `true` when the change was driven by the coordinator
+    /// (e.g. a control task or a startup broadcast while a control task is in-flight).
+    /// It is `false` for changes that came purely from external observation (background
+    /// polling, or an unsolicited startup broadcast with no active control task).
+    StateChanged {
+        from: HostState,
+        to: HostState,
+        coordinator_initiated: bool,
+    },
     /// The lease set for a host changed.
-    LeaseChanged { leases: LeaseSources },
+    ///
+    /// `all_leases` is a snapshot of the **full** lease map at the moment of the change,
+    /// allowing consumers to make decisions based on the complete picture without a separate
+    /// subscription to the lease store.
+    LeaseChanged { leases: LeaseSources, all_leases: Arc<LeaseMap> },
 }
 
 #[derive(Debug, Clone)]
@@ -105,7 +118,8 @@ pub(crate) enum HostCmd {
 
     /// The lease set for `host` changed; the actor re-emits it as a
     /// [`HostEventType::LeaseChanged`] so all consumers can use a single stream.
-    LeaseChanged { host: String, leases: LeaseSources },
+    /// `all_leases` is the full lease map snapshot at the time of the change.
+    LeaseChanged { host: String, leases: LeaseSources, all_leases: Arc<LeaseMap> },
 }
 
 // ---------------------------------------------------------------------------
@@ -127,7 +141,11 @@ struct HostActor {
 impl HostActor {
     /// Apply a state transition for `host`, publishing to the watch and event
     /// channels if the state actually changed.
-    fn apply_state_change(&mut self, host: &str, new_state: HostState) {
+    ///
+    /// `coordinator_initiated` should be `true` when the change originates from
+    /// a coordinator-driven action (control task or in-flight startup broadcast),
+    /// and `false` for externally-observed changes (polling, unsolicited broadcast).
+    fn apply_state_change(&mut self, host: &str, new_state: HostState, coordinator_initiated: bool) {
         let old = self.states.get(host).copied().unwrap_or(HostState::Offline);
         if old == new_state {
             return;
@@ -148,6 +166,7 @@ impl HostActor {
             event: HostEventType::StateChanged {
                 from: old,
                 to: new_state,
+                coordinator_initiated,
             },
         }));
     }
@@ -177,7 +196,7 @@ impl HostActor {
                         );
                         continue;
                     }
-                    self.apply_state_change(&host, new_state);
+                    self.apply_state_change(&host, new_state, false);
                 }
                 // Reply with the post-apply snapshot so the caller observes the
                 // definitive state without a separate watch read.
@@ -187,7 +206,10 @@ impl HostActor {
             HostCmd::StartupBroadcast { host } => {
                 // The control task (if any) remains the owner; we just update
                 // the visible state so the UI and watch subscribers are current.
-                self.apply_state_change(&host, HostState::Online);
+                // coordinator_initiated is true only when a control task is in-flight
+                // (i.e. we woke the host); false means the host booted unsolicited.
+                let coordinator_initiated = self.control_active.contains(&host);
+                self.apply_state_change(&host, HostState::Online, coordinator_initiated);
             }
 
             HostCmd::BeginTransition {
@@ -215,7 +237,7 @@ impl HostActor {
                     OperationKind::Shutdown => HostState::ShuttingDown,
                 };
                 self.control_active.insert(host.clone());
-                self.apply_state_change(&host, transition_state);
+                self.apply_state_change(&host, transition_state, true);
                 let _ = reply.send(true);
             }
 
@@ -225,14 +247,14 @@ impl HostActor {
                     TransitionResult::WakeOk | TransitionResult::ShutdownErr => HostState::Online,
                     TransitionResult::WakeErr | TransitionResult::ShutdownOk => HostState::Offline,
                 };
-                self.apply_state_change(&host, final_state);
+                self.apply_state_change(&host, final_state, true);
             }
 
-            HostCmd::LeaseChanged { host, leases } => {
+            HostCmd::LeaseChanged { host, leases, all_leases } => {
                 drop(self.event_tx.send(FullHostEvent {
                     host,
                     at: Instant::now(),
-                    event: HostEventType::LeaseChanged { leases },
+                    event: HostEventType::LeaseChanged { leases, all_leases },
                 }));
             }
         }
@@ -358,8 +380,20 @@ impl HostActorHandle {
 
     /// Notify the actor (and event stream subscribers) that the lease set for
     /// `host` changed.
-    pub(crate) async fn notify_lease_changed(&self, host: String, leases: LeaseSources) {
-        drop(self.tx.send(HostCmd::LeaseChanged { host, leases }).await);
+    ///
+    /// `all_leases` is the full current lease map snapshot, passed through to
+    /// [`HostEventType::LeaseChanged`] so consumers don't need a direct lease-store subscription.
+    pub(crate) async fn notify_lease_changed(
+        &self,
+        host: String,
+        leases: LeaseSources,
+        all_leases: Arc<LeaseMap>,
+    ) {
+        drop(
+            self.tx
+                .send(HostCmd::LeaseChanged { host, leases, all_leases })
+                .await,
+        );
     }
 
     // ------------------------------------------------------------------
@@ -606,10 +640,15 @@ mod tests {
 
         let ev = ev_rx.try_recv().expect("event should be available");
         match ev.event {
-            HostEventType::StateChanged { from, to } => {
+            HostEventType::StateChanged {
+                from,
+                to,
+                coordinator_initiated,
+            } => {
                 assert_eq!(ev.host, "srv");
                 assert_eq!(from, HostState::Offline);
                 assert_eq!(to, HostState::Waking);
+                assert!(coordinator_initiated, "BeginTransition must be coordinator_initiated");
             }
             HostEventType::LeaseChanged { .. } => panic!("unexpected event"),
         }
@@ -621,16 +660,22 @@ mod tests {
         let mut ev_rx = actor.event_tx.subscribe();
 
         let leases: LeaseSources = vec![LeaseSource::WebInterface].into_iter().collect();
+        let all_leases = Arc::new(LeaseMap::from([("srv".to_string(), leases.clone())]));
         actor.handle_cmd(HostCmd::LeaseChanged {
             host: "srv".to_string(),
             leases: leases.clone(),
+            all_leases: Arc::clone(&all_leases),
         });
 
         let ev = ev_rx.try_recv().expect("event should be available");
         match ev.event {
-            HostEventType::LeaseChanged { leases: got_leases } => {
+            HostEventType::LeaseChanged {
+                leases: got_leases,
+                all_leases: got_all,
+            } => {
                 assert_eq!(ev.host, "srv");
                 assert_eq!(got_leases, leases);
+                assert_eq!(got_all, all_leases);
             }
             HostEventType::StateChanged { .. } => panic!("unexpected event"),
         }
@@ -652,5 +697,56 @@ mod tests {
             ev_rx.try_recv().is_err(),
             "no event expected for no-op state write"
         );
+    }
+
+    #[test]
+    fn startup_broadcast_with_active_control_is_coordinator_initiated() {
+        let mut actor = make_actor();
+        // Simulate a control task in-flight by inserting into control_active.
+        actor.control_active.insert("srv".to_string());
+        let mut ev_rx = actor.event_tx.subscribe();
+
+        actor.handle_cmd(HostCmd::StartupBroadcast {
+            host: "srv".to_string(),
+        });
+
+        let ev = ev_rx.try_recv().expect("event should be emitted");
+        match ev.event {
+            HostEventType::StateChanged {
+                coordinator_initiated,
+                ..
+            } => {
+                assert!(
+                    coordinator_initiated,
+                    "StartupBroadcast while control_active must set coordinator_initiated"
+                );
+            }
+            _ => panic!("expected StateChanged"),
+        }
+    }
+
+    #[test]
+    fn startup_broadcast_without_active_control_is_not_coordinator_initiated() {
+        let mut actor = make_actor();
+        // No control task active.
+        let mut ev_rx = actor.event_tx.subscribe();
+
+        actor.handle_cmd(HostCmd::StartupBroadcast {
+            host: "srv".to_string(),
+        });
+
+        let ev = ev_rx.try_recv().expect("event should be emitted");
+        match ev.event {
+            HostEventType::StateChanged {
+                coordinator_initiated,
+                ..
+            } => {
+                assert!(
+                    !coordinator_initiated,
+                    "StartupBroadcast without control_active must NOT set coordinator_initiated"
+                );
+            }
+            _ => panic!("expected StateChanged"),
+        }
     }
 }

--- a/coordinator/src/app/host_actor.rs
+++ b/coordinator/src/app/host_actor.rs
@@ -735,7 +735,7 @@ mod tests {
                     "StartupBroadcast while control_active must set coordinator_initiated"
                 );
             }
-            _ => panic!("expected StateChanged"),
+            HostEventType::LeaseChanged { .. } => panic!("expected StateChanged"),
         }
     }
 
@@ -760,7 +760,7 @@ mod tests {
                     "StartupBroadcast without control_active must NOT set coordinator_initiated"
                 );
             }
-            _ => panic!("expected StateChanged"),
+            HostEventType::LeaseChanged { .. } => panic!("expected StateChanged"),
         }
     }
 }

--- a/coordinator/src/app/host_actor.rs
+++ b/coordinator/src/app/host_actor.rs
@@ -12,7 +12,7 @@
 //! visible state.
 
 use alloc::sync::Arc;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use tokio::{
     sync::{broadcast, mpsc, oneshot, watch},
@@ -22,8 +22,13 @@ use tracing::{debug, warn};
 
 use crate::app::{
     host_control::LeaseSources,
-    state::{HostState, HostStatus, OperationKind},
+    state::{HostState, OperationKind},
 };
+
+/// The full online/offline + transition state map for all known hosts.
+pub type HostStatus = HashMap<String, HostState>;
+/// Watch receiver for [`HostStatus`] snapshots published by the [`HostActorHandle`].
+pub(crate) type HostStatusRx = watch::Receiver<Arc<HostStatus>>;
 
 // ---------------------------------------------------------------------------
 // Public types

--- a/coordinator/src/app/host_actor.rs
+++ b/coordinator/src/app/host_actor.rs
@@ -14,10 +14,7 @@
 use alloc::sync::Arc;
 use std::collections::{HashMap, HashSet};
 
-use tokio::{
-    sync::{broadcast, mpsc, oneshot, watch},
-    time::Instant,
-};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tracing::{debug, warn};
 
 use crate::app::{
@@ -76,7 +73,6 @@ pub(crate) enum HostEventType {
 #[derive(Debug, Clone)]
 pub(crate) struct FullHostEvent {
     pub(crate) host: String,
-    pub(crate) at: Instant,
     pub(crate) event: HostEventType,
 }
 
@@ -149,7 +145,12 @@ impl HostActor {
     /// `coordinator_initiated` should be `true` when the change originates from
     /// a coordinator-driven action (control task or in-flight startup broadcast),
     /// and `false` for externally-observed changes (polling, unsolicited broadcast).
-    fn apply_state_change(&mut self, host: &str, new_state: HostState, coordinator_initiated: bool) {
+    fn apply_state_change(
+        &mut self,
+        host: &str,
+        new_state: HostState,
+        coordinator_initiated: bool,
+    ) {
         let old = self.states.get(host).copied().unwrap_or(HostState::Offline);
         if old == new_state {
             return;
@@ -166,7 +167,6 @@ impl HostActor {
         // Emit a typed event.
         drop(self.event_tx.send(FullHostEvent {
             host: host.to_string(),
-            at: Instant::now(),
             event: HostEventType::StateChanged {
                 from: old,
                 to: new_state,
@@ -254,10 +254,13 @@ impl HostActor {
                 self.apply_state_change(&host, final_state, true);
             }
 
-            HostCmd::LeaseChanged { host, leases, all_leases } => {
+            HostCmd::LeaseChanged {
+                host,
+                leases,
+                all_leases,
+            } => {
                 drop(self.event_tx.send(FullHostEvent {
                     host,
-                    at: Instant::now(),
                     event: HostEventType::LeaseChanged { leases, all_leases },
                 }));
             }
@@ -395,7 +398,11 @@ impl HostActorHandle {
     ) {
         drop(
             self.tx
-                .send(HostCmd::LeaseChanged { host, leases, all_leases })
+                .send(HostCmd::LeaseChanged {
+                    host,
+                    leases,
+                    all_leases,
+                })
                 .await,
         );
     }
@@ -652,7 +659,10 @@ mod tests {
                 assert_eq!(ev.host, "srv");
                 assert_eq!(from, HostState::Offline);
                 assert_eq!(to, HostState::Waking);
-                assert!(coordinator_initiated, "BeginTransition must be coordinator_initiated");
+                assert!(
+                    coordinator_initiated,
+                    "BeginTransition must be coordinator_initiated"
+                );
             }
             HostEventType::LeaseChanged { .. } => panic!("unexpected event"),
         }

--- a/coordinator/src/app/host_actor.rs
+++ b/coordinator/src/app/host_actor.rs
@@ -54,22 +54,23 @@ pub(crate) enum TransitionResult {
 #[derive(Debug, Clone)]
 pub(crate) enum HostEventType {
     /// A host's visible [`HostState`] changed.
-    ///
-    /// `coordinator_initiated` is `true` when the change was driven by the coordinator
-    /// (e.g. a control task or a startup broadcast while a control task is in-flight).
-    /// It is `false` for changes that came purely from external observation (background
-    /// polling, or an unsolicited startup broadcast with no active control task).
     StateChanged {
         from: HostState,
         to: HostState,
+        /// `true` when the change was driven by the coordinator
+        /// (e.g. a control task or a startup broadcast while a control task is in-flight).
+        /// `false` for changes that came purely from external observation (background
+        /// polling, or an unsolicited startup broadcast with no active control task).
         coordinator_initiated: bool,
     },
     /// The lease set for a host changed.
-    ///
-    /// `all_leases` is a snapshot of the **full** lease map at the moment of the change,
-    /// allowing consumers to make decisions based on the complete picture without a separate
-    /// subscription to the lease store.
-    LeaseChanged { leases: LeaseSources, all_leases: Arc<LeaseMap> },
+    LeaseChanged {
+        leases: LeaseSources,
+        /// A snapshot of the **full** lease map at the moment of the change,
+        /// allowing consumers to make decisions based on the complete picture without a separate
+        /// subscription to the lease store.
+        all_leases: Arc<LeaseMap>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -86,9 +87,9 @@ pub(crate) struct FullHostEvent {
 pub(crate) enum HostCmd {
     /// Batch of polled (Online/Offline) observations from the background poller.
     /// Ignored for any host currently under control-task ownership.
-    /// The actor sends the resulting snapshot back via `reply` once processed.
     PollResults {
         results: Vec<(String, HostState)>,
+        /// Receives the post-apply host-status snapshot once processed.
         reply: oneshot::Sender<Arc<HostStatus>>,
     },
 
@@ -99,13 +100,12 @@ pub(crate) enum HostCmd {
     StartupBroadcast { host: String },
 
     /// Atomically claim a transition slot for `host`.
-    ///
-    /// Replies `true` if the slot was claimed (host is now `Waking` or
-    /// `ShuttingDown` and added to `control_active`), `false` if already
-    /// claimed or already in a transition state.
     BeginTransition {
         host: String,
         direction: OperationKind,
+        /// Receives `true` if the slot was claimed (host is now `Waking` or
+        /// `ShuttingDown` and added to `control_active`), `false` if already
+        /// claimed or already in a transition state.
         reply: oneshot::Sender<bool>,
     },
 
@@ -118,8 +118,12 @@ pub(crate) enum HostCmd {
 
     /// The lease set for `host` changed; the actor re-emits it as a
     /// [`HostEventType::LeaseChanged`] so all consumers can use a single stream.
-    /// `all_leases` is the full lease map snapshot at the time of the change.
-    LeaseChanged { host: String, leases: LeaseSources, all_leases: Arc<LeaseMap> },
+    LeaseChanged {
+        host: String,
+        leases: LeaseSources,
+        /// The full lease map snapshot at the time of the change.
+        all_leases: Arc<LeaseMap>,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/coordinator/src/app/host_control.rs
+++ b/coordinator/src/app/host_control.rs
@@ -58,19 +58,19 @@ impl ops::Deref for ResolvedHost {
 pub(crate) type LeaseSources = HashSet<LeaseSource>;
 
 /// `host_name` => set of lease sources holding lease
-pub(crate) type LeaseMapRaw = HashMap<String, LeaseSources>;
+pub(crate) type LeaseMap = HashMap<String, LeaseSources>;
 
-pub(crate) type LeaseStore = SharedWatchStore<LeaseMapRaw>;
-pub(crate) type LeaseRx = SharedWatchRx<LeaseMapRaw>;
+pub(crate) type LeaseStore = SharedWatchStore<LeaseMap>;
+pub(crate) type LeaseRx = SharedWatchRx<LeaseMap>;
 
-impl SharedWatchStore<LeaseMapRaw> {
+impl SharedWatchStore<LeaseMap> {
     /// Lock the map, run `f` against the mutable map (may do async work such as
     /// DB writes), then publish the new snapshot and return it.
     ///
     /// If `f` returns an error the map is not published and the error is forwarded.
     pub(crate) async fn update<F, E, R>(&self, f: F) -> Result<R, E>
     where
-        F: AsyncFnOnce(&mut LeaseMapRaw) -> Result<R, E>,
+        F: AsyncFnOnce(&mut LeaseMap) -> Result<R, E>,
     {
         let mut guard = self.inner.lock().await;
         let mut snapshot = guard.clone();

--- a/coordinator/src/app/mod.rs
+++ b/coordinator/src/app/mod.rs
@@ -18,7 +18,6 @@ pub(crate) use host_control::{
     HostControlError, LeaseMap, LeaseRx, LeaseSource, LeaseSources, LeaseStore, lookup_host,
     lookup_host_with_overrides, wait_for_transition,
 };
-pub use runtime::ENFORCE_STABILIZATION_THRESHOLD;
 pub(crate) use startup::{shutdown_signal, start};
 pub(crate) use state::{AppState, ConfigRx, RwMap, WsTx};
 

--- a/coordinator/src/app/mod.rs
+++ b/coordinator/src/app/mod.rs
@@ -12,14 +12,15 @@ mod update_check;
 
 // Re-export a curated crate-visible surface for consumers of `crate::app`
 pub(crate) use db::DbPool;
-pub(crate) use host_actor::HostActorHandle;
+pub use host_actor::HostStatus;
+pub(crate) use host_actor::{HostActorHandle, HostStatusRx};
 pub(crate) use host_control::{
     HostControlError, LeaseMapRaw, LeaseRx, LeaseSource, LeaseSources, LeaseStore, lookup_host,
     lookup_host_with_overrides, wait_for_transition,
 };
 pub use runtime::ENFORCE_STABILIZATION_THRESHOLD;
 pub(crate) use startup::{shutdown_signal, start};
-pub(crate) use state::{AppState, ConfigRx, HostStatusRx, RwMap, WsTx};
+pub(crate) use state::{AppState, ConfigRx, RwMap, WsTx};
 
 pub(crate) use state::OperationFailureStore;
-pub use state::{HostState, HostStatus, OperationFailure, OperationFailureMap, OperationKind};
+pub use state::{HostState, OperationFailure, OperationFailureMap, OperationKind};

--- a/coordinator/src/app/mod.rs
+++ b/coordinator/src/app/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use db::DbPool;
 pub use host_actor::HostStatus;
 pub(crate) use host_actor::{HostActorHandle, HostStatusRx};
 pub(crate) use host_control::{
-    HostControlError, LeaseMapRaw, LeaseRx, LeaseSource, LeaseSources, LeaseStore, lookup_host,
+    HostControlError, LeaseMap, LeaseRx, LeaseSource, LeaseSources, LeaseStore, lookup_host,
     lookup_host_with_overrides, wait_for_transition,
 };
 pub use runtime::ENFORCE_STABILIZATION_THRESHOLD;

--- a/coordinator/src/app/notifications.rs
+++ b/coordinator/src/app/notifications.rs
@@ -44,11 +44,11 @@ pub(crate) enum EventKind {
     Unscheduled {
         kind: OperationKind,
     },
-    /// `is_repeat` is `true` when the same failure kind was already recorded for
-    /// this host (i.e. a previous enforce-state retry). Webhooks always fire;
-    /// PWA push is suppressed for repeats.
     OperationFailed {
         kind: OperationKind,
+        /// `true` when the same failure kind was already recorded for
+        /// this host (i.e. a previous enforce-state retry). Webhooks always fire;
+        /// PWA push is suppressed for repeats.
         is_repeat: bool,
     },
     OnlineFor {

--- a/coordinator/src/app/runtime.rs
+++ b/coordinator/src/app/runtime.rs
@@ -28,7 +28,8 @@ use shuthost_common::{
     validate_hmac_message,
 };
 
-use super::state::{ConfigRx, ConfigTx, HostInstallInfo, HostState, HostStatus, OperationKind};
+use super::state::{ConfigRx, ConfigTx, HostInstallInfo, HostState, OperationKind};
+use super::host_actor::HostStatus;
 use crate::{
     app::{
         AppState, HostActorHandle, LeaseMapRaw, LeaseRx, OperationFailureMap, WsTx,
@@ -45,6 +46,22 @@ use crate::app::{host_control::HostWithName, notifications};
 /// How long a diverged enforced-host state must be stable before the enforcer
 /// re-triggers a wake / shutdown (prevents hammering during transitions).
 pub const ENFORCE_STABILIZATION_THRESHOLD: Duration = Duration::from_secs(5);
+
+/// Receive one event from a broadcast channel, logging a warning on lag and breaking on close.
+///
+/// Takes a pre-resolved `Result<T, RecvError>` and evaluates to `T`. Must be used inside a `loop`.
+macro_rules! next_broadcast_event {
+    ($result:expr, $label:literal) => {
+        match $result {
+            Ok(e) => e,
+            Err(RecvError::Lagged(n)) => {
+                warn!(concat!($label, ": missed {} events (broadcast channel lagged)"), n);
+                continue;
+            }
+            Err(RecvError::Closed) => break,
+        }
+    };
+}
 
 /// Poll a single host for its online status.
 async fn poll_host_status(host: &HostWithName) -> (HostState, Option<HostInstallInfo>) {
@@ -219,21 +236,17 @@ pub(super) fn start_background_tasks(
         config_tx.clone(),
     ));
 
-    // Reconcile host state on lease changes (edge-triggered, all hosts)
-    tasks.spawn(reconcile_on_lease_change(
-        state.leases.subscribe(),
-        state.clone(),
-    ));
+    // Reconcile host state on lease changes (edge-triggered, per-host via actor event stream)
+    tasks.spawn(reconcile_on_lease_change(state.clone()));
 
     tasks.spawn(listen_for_agent_startup(state.clone(), broadcast_socket));
 
     spawn_websocket_forwarders(
         &mut tasks,
         &state.ws_tx,
-        state.host_actor.subscribe_status(),
         state.operation_failures.subscribe(),
         state.config_rx.clone(),
-        state.leases.subscribe(),
+        state.host_actor.clone(),
     );
 
     tasks.spawn(log_host_transitions(state.host_actor.subscribe_status()));
@@ -278,23 +291,34 @@ pub(super) fn start_background_tasks(
 fn spawn_websocket_forwarders(
     tasks: &mut JoinSet<()>,
     ws_tx: &WsTx,
-    mut hoststatus_rx: SharedWatchRx<HostStatus>,
     mut op_failure_rx: SharedWatchRx<OperationFailureMap>,
     config_rx: ConfigRx,
-    leases_rx: LeaseRx,
+    host_actor: HostActorHandle,
 ) {
-    // Forwards host status updates to the websocket client loops
-    let ws_tx_status = ws_tx.clone();
+    // Forwards host state and lease changes to WebSocket clients via the actor event stream.
+    // StateChanged → full HostStatus snapshot (with config-defined hosts filled in as Offline).
+    // LeaseChanged  → per-host LeaseUpdate.
+    let ws_tx_events = ws_tx.clone();
     let config_rx_for_status = config_rx.clone();
     tasks.spawn(async move {
-        while hoststatus_rx.changed().await.is_ok() {
-            let mut status_map = hoststatus_rx.borrow().as_ref().clone();
-            let config = config_rx_for_status.borrow();
-            for host in config.hosts.keys() {
-                status_map.entry(host.clone()).or_insert(HostState::Offline);
-            }
-            let msg = WsMessage::HostStatus(status_map);
-            if ws_tx_status.send(msg).is_err() {
+        let mut events_rx = host_actor.subscribe_events();
+        loop {
+            let event = next_broadcast_event!(events_rx.recv().await, "ws_forwarder");
+            let msg = match event.event {
+                HostEventType::StateChanged { .. } => {
+                    let mut status_map = host_actor.borrow().as_ref().clone();
+                    let config = config_rx_for_status.borrow();
+                    for host in config.hosts.keys() {
+                        status_map.entry(host.clone()).or_insert(HostState::Offline);
+                    }
+                    WsMessage::HostStatus(status_map)
+                }
+                HostEventType::LeaseChanged { leases } => WsMessage::LeaseUpdate {
+                    host: event.host,
+                    leases,
+                },
+            };
+            if ws_tx_events.send(msg).is_err() {
                 debug!("No Websocket Subscribers");
             }
         }
@@ -323,11 +347,6 @@ fn spawn_websocket_forwarders(
                 debug!("No Websocket Subscribers");
             }
         }
-    });
-
-    let ws_tx_leases = ws_tx.clone();
-    tasks.spawn(async move {
-        broadcast_lease_updates(leases_rx, ws_tx_leases).await;
     });
 }
 
@@ -695,15 +714,8 @@ async fn handle_host_events(
                 current_leases = leases_rx.borrow().clone();
             }
             // React to host state transitions.
-            event = events_rx.recv() => {
-                let event = match event {
-                    Ok(e) => e,
-                    Err(RecvError::Lagged(n)) => {
-                        warn!("handle_host_events: missed {n} events (broadcast channel lagged)");
-                        continue;
-                    }
-                    Err(RecvError::Closed) => break,
-                };
+            recv_result = events_rx.recv() => {
+                let event = next_broadcast_event!(recv_result, "handle_host_events");
 
                 let HostEventType::StateChanged { from, to } = event.event else {
                     continue;
@@ -783,86 +795,36 @@ async fn forward_lease_events(mut leases_rx: LeaseRx, host_actor: HostActorHandl
     }
 }
 
-/// Background task: forwards per-host lease changes to WebSocket clients.
-async fn broadcast_lease_updates(mut leases_rx: LeaseRx, ws_tx: WsTx) {
-    let mut prev_leases: Arc<LeaseMapRaw> = leases_rx.borrow_and_update().clone();
 
-    while leases_rx.changed().await.is_ok() {
-        let new_leases: Arc<LeaseMapRaw> = leases_rx.borrow_and_update().clone();
+/// Background task: reconcile host control on every per-host lease change.
+///
+/// Consumes [`HostEventType::LeaseChanged`] events from the actor's broadcast stream
+/// (populated by [`forward_lease_events`]). Each event carries the new lease set for
+/// exactly the host that changed, so no full-map diff or `prev_desired` tracking is needed.
+///
+/// On broadcast lag the missed events are simply skipped; any divergence for hosts with
+/// `enforce_state = true` will be caught by the periodic poller.
+async fn reconcile_on_lease_change(state: AppState) {
+    let mut events_rx = state.host_actor.subscribe_events();
+    loop {
+        let event = next_broadcast_event!(events_rx.recv().await, "reconcile_on_lease_change");
 
-        // Collect all host names that appear in either snapshot.
-        let all_hosts: HashSet<&str> = prev_leases
-            .keys()
-            .chain(new_leases.keys())
-            .map(String::as_str)
-            .collect();
+        let HostEventType::LeaseChanged { leases } = event.event else {
+            continue;
+        };
+        let host_name = &event.host;
+        let desired_running = !leases.is_empty();
 
-        for host in all_hosts {
-            if prev_leases.get(host) != new_leases.get(host) {
-                let leases = new_leases.get(host).cloned().unwrap_or_default();
-                let msg = WsMessage::LeaseUpdate {
-                    host: host.to_string(),
-                    leases,
-                };
-                if ws_tx.send(msg).is_err() {
-                    debug!("No Websocket Subscribers");
-                }
-            }
+        let current_state = state.host_actor.get_current_state(host_name);
+
+        // Skip hosts already in a transition — the in-flight task re-checks on completion.
+        if current_state.is_transitioning() {
+            continue;
         }
 
-        prev_leases = new_leases;
-    }
-}
-
-/// Background task: reconcile host control on every lease-map change (edge-triggered, all hosts).
-async fn reconcile_on_lease_change(mut leases_rx: LeaseRx, state: AppState) {
-    // Build a map from host → desired_running for every host currently in the lease map.
-    // A host absent from this map has never been seen in the lease map (treated as None).
-    //
-    // Using a full HashMap rather than a subset-set (e.g. "desired_offline" or "desired_online")
-    // means ALL transitions are detected:
-    //   None  → Some(true)  – first-ever lease added          → trigger startup
-    //   None  → Some(false) – first explicit release (no prior lease) → shutdown check
-    //   Some(true)  → Some(false) – lease released            → trigger shutdown
-    //   Some(false) → Some(true)  – new lease                 → trigger startup
-    // The old "desired_offline" approach missed the None→Some(true) case (Bug #1).
-    // The "desired_online" approach missed the None→Some(false) case.
-    fn get_desired_map(leases: &LeaseMapRaw) -> HashMap<String, bool> {
-        leases
-            .iter()
-            .map(|(host, lease_set)| (host.clone(), !lease_set.is_empty()))
-            .collect()
-    }
-
-    let mut prev_desired = get_desired_map(&leases_rx.borrow_and_update());
-
-    while leases_rx.changed().await.is_ok() {
-        let new_leases = leases_rx.borrow_and_update();
-        let new_desired = get_desired_map(&new_leases);
-        let hoststatus = state.host_actor.borrow();
-
-        for (host_name, &desired_running) in &new_desired {
-            let prev = prev_desired.get(host_name).copied();
-            // Act if: newly added to lease map (None), or desired running changed.
-            if prev == Some(desired_running) {
-                continue;
-            }
-
-            let current_state = *hoststatus.get(host_name).unwrap_or(&HostState::Offline);
-
-            // Skip hosts already in a transition — the in-flight task re-checks on completion.
-            if current_state.is_transitioning() {
-                continue;
-            }
-
-            let is_running = current_state == HostState::Online;
-
-            if desired_running != is_running {
-                spawn_handle_host_state(host_name, &state);
-            }
+        if desired_running != (current_state == HostState::Online) {
+            spawn_handle_host_state(host_name, &state);
         }
-
-        prev_desired = new_desired;
     }
 }
 

--- a/coordinator/src/app/runtime.rs
+++ b/coordinator/src/app/runtime.rs
@@ -32,7 +32,7 @@ use super::state::{ConfigRx, ConfigTx, HostInstallInfo, HostState, HostStatus, O
 use crate::{
     app::{
         AppState, HostActorHandle, LeaseMapRaw, LeaseRx, OperationFailureMap, WsTx,
-        config_watcher::watch_config_file, db, host_actor::HostEvent,
+        config_watcher::watch_config_file, db, host_actor::FullHostEvent, host_actor::HostEventType,
         host_control::spawn_handle_host_state, shared_watch_store::SharedWatchRx,
     },
     config::{Host, StructuredEventFilter, WebhookEventFilter},
@@ -667,14 +667,14 @@ async fn spawn_push_online_for_timers(
     }
 }
 
-/// Background task: consumes the [`HostEvent`] stream and fires push notifications
+/// Background task: consumes the [`FullHostEvent`] stream and fires push notifications
 /// for unscheduled host state transitions.
 ///
 /// An event is "unscheduled" when:
 /// - `Offline → Online` with no active leases (host booted without coordinator involvement).
 /// - `Online → Offline` while leases are held (host went offline unexpectedly).
 async fn handle_host_events(
-    mut events_rx: broadcast::Receiver<HostEvent>,
+    mut events_rx: broadcast::Receiver<FullHostEvent>,
     initial_leases: Arc<LeaseMapRaw>,
     db_pool: Option<db::DbPool>,
     vapid_key: Option<Arc<ES256KeyPair>>,
@@ -705,9 +705,10 @@ async fn handle_host_events(
                     Err(RecvError::Closed) => break,
                 };
 
-                let HostEvent::StateChanged { host: host_name, from, to, .. } = event else {
+                let HostEventType::StateChanged { from, to } = event.event else {
                     continue;
                 };
+                let host_name = event.host;
 
                 let has_leases = current_leases
                     .get(&host_name)

--- a/coordinator/src/app/runtime.rs
+++ b/coordinator/src/app/runtime.rs
@@ -274,7 +274,6 @@ pub(super) fn start_background_tasks(
         state.leases.snapshot(),
         state.db_pool.clone(),
         state.vapid_key.clone(),
-        state.leases.subscribe(),
         state.config_rx.clone(),
     ));
 
@@ -311,7 +310,7 @@ fn spawn_websocket_forwarders(
                     }
                     WsMessage::HostStatus(status_map)
                 }
-                HostEventType::LeaseChanged { leases } => WsMessage::LeaseUpdate {
+                HostEventType::LeaseChanged { leases, .. } => WsMessage::LeaseUpdate {
                     host: event.host,
                     leases,
                 },
@@ -688,86 +687,89 @@ async fn spawn_push_online_for_timers(
 /// for unscheduled host state transitions.
 ///
 /// An event is "unscheduled" when:
-/// - `Offline → Online` with no active leases (host booted without coordinator involvement).
+/// - `coordinator_initiated` is `false` (change not driven by a coordinator control task), AND
+/// - `Offline → Online` with no active leases (host booted without coordinator involvement), OR
 /// - `Online → Offline` while leases are held (host went offline unexpectedly).
+///
+/// `current_leases` is kept up-to-date by consuming [`HostEventType::LeaseChanged`] events from
+/// the **same** broadcast channel as [`HostEventType::StateChanged`]. Because both event kinds
+/// are ordered within a single channel, a `StateChanged` can never be observed before a
+/// `LeaseChanged` that happened earlier in the actor — eliminating the `tokio::select!` ordering
+/// race of the previous implementation. No direct lease-store subscription is needed.
 async fn report_unscheduled_events(
     mut events_rx: broadcast::Receiver<FullHostEvent>,
     initial_leases: Arc<LeaseMap>,
     db_pool: Option<db::DbPool>,
     vapid_key: Option<Arc<ES256KeyPair>>,
-    mut leases_rx: LeaseRx,
     config_rx: ConfigRx,
 ) {
-    // Keep a local copy of the lease map so we can check it at event time without
-    // holding a lock on the LeaseStore.
     let mut current_leases = initial_leases;
-
     loop {
-        tokio::select! {
-            // Update our local lease snapshot whenever it changes.
-            result = leases_rx.changed() => {
-                if result.is_err() {
-                    break;
-                }
-                current_leases = leases_rx.borrow().clone();
-            }
-            // React to host state transitions.
-            recv_result = events_rx.recv() => {
-                let event = next_broadcast_event!(recv_result, "handle_host_events");
+        let event = next_broadcast_event!(events_rx.recv().await, "report_unscheduled_events");
 
-                let HostEventType::StateChanged { from, to } = event.event else {
-                    continue;
-                };
-                let host_name = event.host;
-
-                let has_leases = current_leases
-                    .get(&host_name)
-                    .is_some_and(|s| !s.is_empty());
-
-                use HostState as HS;
-
-                let is_unscheduled = match (from, to) {
-                    // Host came online without the coordinator waking it.
-                    (HS::Offline, HS::Online) => !has_leases,
-                    // Host went offline while the coordinator expected it to stay up.
-                    (HS::Online, HS::Offline) => has_leases,
-                    _ => false,
-                };
-
-                if !is_unscheduled {
-                    continue;
-                }
-
-                let notification_event = match to {
-                    HS::Online => NotificationEvent {
-                        host: host_name.clone(),
-                        kind: EventKind::Unscheduled {
-                            kind: OperationKind::Startup,
-                        },
-                    },
-                    HS::Offline => NotificationEvent {
-                        host: host_name.clone(),
-                        kind: EventKind::Unscheduled {
-                            kind: OperationKind::Shutdown,
-                        },
-                    },
-                    HS::Waking | HS::ShuttingDown => continue,
-                };
-
-                let webhooks = config_rx.borrow().notifications.webhooks.clone();
-                let pool_clone = db_pool.clone();
-                let vapid_clone = vapid_key.clone();
-                tokio::spawn(async move {
-                    notifications::dispatch(
-                        notification_event,
-                        &webhooks,
-                        pool_clone.as_ref(),
-                        vapid_clone.as_ref(),
-                    )
-                    .await;
-                });
-            }
+        // Keep current_leases up-to-date from lease events in the same stream.
+        if let HostEventType::LeaseChanged { all_leases, .. } = &event.event {
+            current_leases = Arc::clone(all_leases);
+            continue;
         }
+
+        let HostEventType::StateChanged { from, to, coordinator_initiated } = event.event else {
+            continue;
+        };
+
+        // Fast-path: changes driven by the coordinator are never "unscheduled".
+        // This also covers the race where a lease is taken and a WoL control task
+        // is in-flight at the same time the host boots.
+        if coordinator_initiated {
+            continue;
+        }
+
+        let has_leases = current_leases
+            .get(&event.host)
+            .is_some_and(|s| !s.is_empty());
+
+        use HostState as HS;
+
+        let is_unscheduled = match (from, to) {
+            // Host came online without the coordinator waking it.
+            (HS::Offline, HS::Online) => !has_leases,
+            // Host went offline while the coordinator expected it to stay up.
+            (HS::Online, HS::Offline) => has_leases,
+            _ => false,
+        };
+
+        if !is_unscheduled {
+            continue;
+        }
+
+        let notification_event = match to {
+            HS::Online => NotificationEvent {
+                host: event.host.clone(),
+                kind: EventKind::Unscheduled {
+                    kind: OperationKind::Startup,
+                },
+            },
+            HS::Offline => NotificationEvent {
+                host: event.host.clone(),
+                kind: EventKind::Unscheduled {
+                    kind: OperationKind::Shutdown,
+                },
+            },
+            HS::Waking | HS::ShuttingDown => continue,
+        };
+
+        let webhooks = config_rx.borrow().notifications.webhooks.clone();
+        let pool_clone = db_pool.clone();
+        let vapid_clone = vapid_key.clone();
+        tokio::spawn(async move {
+            notifications::dispatch(
+                notification_event,
+                &webhooks,
+                pool_clone.as_ref(),
+                vapid_clone.as_ref(),
+            )
+            .await;
+        });
     }
 }
 
@@ -787,7 +789,7 @@ async fn forward_lease_events(mut leases_rx: LeaseRx, host_actor: HostActorHandl
             if prev_leases.get(host) != new_leases.get(host) {
                 let leases = new_leases.get(host).cloned().unwrap_or_default();
                 host_actor
-                    .notify_lease_changed(host.to_string(), leases)
+                    .notify_lease_changed(host.to_string(), leases, Arc::clone(&new_leases))
                     .await;
             }
         }
@@ -809,7 +811,7 @@ async fn reconcile_on_lease_change(state: AppState) {
     loop {
         let event = next_broadcast_event!(events_rx.recv().await, "reconcile_on_lease_change");
 
-        let HostEventType::LeaseChanged { leases } = event.event else {
+        let HostEventType::LeaseChanged { leases, .. } = event.event else {
             continue;
         };
         let host_name = &event.host;

--- a/coordinator/src/app/runtime.rs
+++ b/coordinator/src/app/runtime.rs
@@ -28,11 +28,17 @@ use shuthost_common::{
     validate_hmac_message,
 };
 
-use super::state::{ConfigRx, ConfigTx, HostInstallInfo, HostState, OperationKind};
 use super::host_actor::HostStatus;
+use super::state::{ConfigRx, ConfigTx, HostInstallInfo, HostState, OperationKind};
 use crate::{
     app::{
-        AppState, HostActorHandle, LeaseMap, LeaseRx, OperationFailureMap, WsTx, config_watcher::watch_config_file, db, host_actor::{FullHostEvent, HostEventType}, host_control::spawn_handle_host_state, notifications::{EventKind, NotificationEvent}, shared_watch_store::SharedWatchRx
+        AppState, HostActorHandle, LeaseMap, LeaseRx, OperationFailureMap, WsTx,
+        config_watcher::watch_config_file,
+        db,
+        host_actor::{FullHostEvent, HostEventType},
+        host_control::spawn_handle_host_state,
+        notifications::{EventKind, NotificationEvent},
+        shared_watch_store::SharedWatchRx,
     },
     config::{Host, StructuredEventFilter, WebhookEventFilter},
     http::push,
@@ -53,7 +59,10 @@ macro_rules! next_broadcast_event {
         match $result {
             Ok(e) => e,
             Err(RecvError::Lagged(n)) => {
-                warn!(concat!($label, ": missed {} events (broadcast channel lagged)"), n);
+                warn!(
+                    concat!($label, ": missed {} events (broadcast channel lagged)"),
+                    n
+                );
                 continue;
             }
             Err(RecvError::Closed) => break,
@@ -713,7 +722,12 @@ async fn report_unscheduled_events(
             continue;
         }
 
-        let HostEventType::StateChanged { from, to, coordinator_initiated } = event.event else {
+        let HostEventType::StateChanged {
+            from,
+            to,
+            coordinator_initiated,
+        } = event.event
+        else {
             continue;
         };
 
@@ -796,7 +810,6 @@ async fn forward_lease_events(mut leases_rx: LeaseRx, host_actor: HostActorHandl
         prev_leases = new_leases;
     }
 }
-
 
 /// Background task: reconcile host control on every per-host lease change.
 ///

--- a/coordinator/src/app/runtime.rs
+++ b/coordinator/src/app/runtime.rs
@@ -47,10 +47,6 @@ use crate::{
 
 use crate::app::{host_control::HostWithName, notifications};
 
-/// How long a diverged enforced-host state must be stable before the enforcer
-/// re-triggers a wake / shutdown (prevents hammering during transitions).
-pub const ENFORCE_STABILIZATION_THRESHOLD: Duration = Duration::from_secs(5);
-
 /// Receive one event from a broadcast channel, logging a warning on lag and breaking on close.
 ///
 /// Takes a pre-resolved `Result<T, RecvError>` and evaluates to `T`. Must be used inside a `loop`.
@@ -1025,6 +1021,8 @@ mod tests {
     use alloc::sync::Arc;
     use core::time::Duration;
     use std::collections::HashSet;
+
+    const ENFORCE_STABILIZATION_THRESHOLD: Duration = Duration::from_secs(5);
 
     fn make_host(enforce: bool) -> Host {
         Host {

--- a/coordinator/src/app/runtime.rs
+++ b/coordinator/src/app/runtime.rs
@@ -713,7 +713,7 @@ async fn report_unscheduled_events(
         let event = next_broadcast_event!(events_rx.recv().await, "report_unscheduled_events");
 
         // Keep current_leases up-to-date from lease events in the same stream.
-        if let HostEventType::LeaseChanged { all_leases, .. } = &event.event {
+        if let &HostEventType::LeaseChanged { ref all_leases, .. } = &event.event {
             current_leases = Arc::clone(all_leases);
             continue;
         }
@@ -1153,7 +1153,10 @@ mod tests {
         // Unscheduled only when no leases are held
         let empty = Arc::new(LeaseMap::new());
         let e = make_state_event("h", HostState::Offline, HostState::Online, false);
-        assert_eq!(unscheduled_transition_to(&e, &empty), Some(HostState::Online));
+        assert_eq!(
+            unscheduled_transition_to(&e, &empty),
+            Some(HostState::Online)
+        );
         let held = leases_for("h", vec![LeaseSource::WebInterface].into_iter().collect());
         assert!(unscheduled_transition_to(&e, &held).is_none());
     }
@@ -1163,7 +1166,10 @@ mod tests {
         // Unscheduled only when leases are still held
         let e = make_state_event("h", HostState::Online, HostState::Offline, false);
         let held = leases_for("h", vec![LeaseSource::WebInterface].into_iter().collect());
-        assert_eq!(unscheduled_transition_to(&e, &held), Some(HostState::Offline));
+        assert_eq!(
+            unscheduled_transition_to(&e, &held),
+            Some(HostState::Offline)
+        );
         let empty = Arc::new(LeaseMap::new());
         assert!(unscheduled_transition_to(&e, &empty).is_none());
     }

--- a/coordinator/src/app/runtime.rs
+++ b/coordinator/src/app/runtime.rs
@@ -718,40 +718,11 @@ async fn report_unscheduled_events(
             continue;
         }
 
-        let HostEventType::StateChanged {
-            from,
-            to,
-            coordinator_initiated,
-        } = event.event
-        else {
+        let Some(to) = unscheduled_transition_to(&event, &current_leases) else {
             continue;
         };
-
-        // Fast-path: changes driven by the coordinator are never "unscheduled".
-        // This also covers the race where a lease is taken and a WoL control task
-        // is in-flight at the same time the host boots.
-        if coordinator_initiated {
-            continue;
-        }
-
-        let has_leases = current_leases
-            .get(&event.host)
-            .is_some_and(|s| !s.is_empty());
 
         use HostState as HS;
-
-        let is_unscheduled = match (from, to) {
-            // Host came online without the coordinator waking it.
-            (HS::Offline, HS::Online) => !has_leases,
-            // Host went offline while the coordinator expected it to stay up.
-            (HS::Online, HS::Offline) => has_leases,
-            _ => false,
-        };
-
-        if !is_unscheduled {
-            continue;
-        }
-
         let notification_event = match to {
             HS::Online => NotificationEvent {
                 host: event.host.clone(),
@@ -1010,6 +981,38 @@ async fn persist_host_override_if_needed(
     }
 }
 
+/// If `event` represents an unscheduled host state transition, returns the target
+/// [`HostState`]; otherwise returns `None`.
+///
+/// A transition is "unscheduled" when it was not driven by the coordinator and
+/// represents a surprising change:
+/// - `Offline → Online` with no active leases (host booted on its own), or
+/// - `Online → Offline` while leases are held (host went offline unexpectedly).
+///
+/// Non-`StateChanged` events, coordinator-initiated transitions, and transitions
+/// involving intermediate states (`Waking`, `ShuttingDown`) all return `None`.
+fn unscheduled_transition_to(event: &FullHostEvent, leases: &LeaseMap) -> Option<HostState> {
+    let HostEventType::StateChanged {
+        from,
+        to,
+        coordinator_initiated,
+    } = event.event
+    else {
+        return None;
+    };
+    if coordinator_initiated {
+        return None;
+    }
+    let has_leases = leases.get(&event.host).is_some_and(|s| !s.is_empty());
+    match (from, to) {
+        // Host came online without the coordinator waking it.
+        (HostState::Offline, HostState::Online) if !has_leases => Some(to),
+        // Host went offline while the coordinator expected it to stay up.
+        (HostState::Online, HostState::Offline) if has_leases => Some(to),
+        _ => None,
+    }
+}
+
 // -------------------------------------------------------------
 // Unit tests for enforcement-related code
 // -------------------------------------------------------------
@@ -1093,6 +1096,76 @@ mod tests {
             ENFORCE_STABILIZATION_THRESHOLD,
             ENFORCE_STABILIZATION_THRESHOLD,
         ));
+    }
+
+    use crate::app::{
+        LeaseMap,
+        host_actor::{FullHostEvent, HostEventType},
+    };
+
+    fn make_state_event(
+        host: &str,
+        from: HostState,
+        to: HostState,
+        coordinator_initiated: bool,
+    ) -> FullHostEvent {
+        FullHostEvent {
+            host: host.to_string(),
+            event: HostEventType::StateChanged {
+                from,
+                to,
+                coordinator_initiated,
+            },
+        }
+    }
+
+    fn leases_for(host: &str, sources: LeaseSources) -> Arc<LeaseMap> {
+        let mut m = LeaseMap::new();
+        m.insert(host.to_string(), sources);
+        Arc::new(m)
+    }
+
+    #[test]
+    fn unscheduled_transition_to_coordinator_initiated_returns_none() {
+        let empty = Arc::new(LeaseMap::new());
+        let e = make_state_event("h", HostState::Offline, HostState::Online, true);
+        assert!(unscheduled_transition_to(&e, &empty).is_none());
+        let e = make_state_event("h", HostState::Online, HostState::Offline, true);
+        let held = leases_for("h", vec![LeaseSource::WebInterface].into_iter().collect());
+        assert!(unscheduled_transition_to(&e, &held).is_none());
+    }
+
+    #[test]
+    fn unscheduled_transition_to_non_state_changed_returns_none() {
+        let empty = Arc::new(LeaseMap::new());
+        let e = FullHostEvent {
+            host: "h".to_string(),
+            event: HostEventType::LeaseChanged {
+                leases: HashSet::new(),
+                all_leases: empty.clone(),
+            },
+        };
+        assert!(unscheduled_transition_to(&e, &empty).is_none());
+    }
+
+    #[test]
+    fn unscheduled_transition_to_offline_to_online() {
+        // Unscheduled only when no leases are held
+        let empty = Arc::new(LeaseMap::new());
+        let e = make_state_event("h", HostState::Offline, HostState::Online, false);
+        assert_eq!(unscheduled_transition_to(&e, &empty), Some(HostState::Online));
+        let held = leases_for("h", vec![LeaseSource::WebInterface].into_iter().collect());
+        assert!(unscheduled_transition_to(&e, &held).is_none());
+    }
+
+    #[test]
+    fn unscheduled_transition_to_online_to_offline() {
+        // Unscheduled only when leases are still held
+        let e = make_state_event("h", HostState::Online, HostState::Offline, false);
+        let held = leases_for("h", vec![LeaseSource::WebInterface].into_iter().collect());
+        assert_eq!(unscheduled_transition_to(&e, &held), Some(HostState::Offline));
+        let empty = Arc::new(LeaseMap::new());
+        assert!(unscheduled_transition_to(&e, &empty).is_none());
     }
 
     #[test]

--- a/coordinator/src/app/runtime.rs
+++ b/coordinator/src/app/runtime.rs
@@ -32,9 +32,7 @@ use super::state::{ConfigRx, ConfigTx, HostInstallInfo, HostState, OperationKind
 use super::host_actor::HostStatus;
 use crate::{
     app::{
-        AppState, HostActorHandle, LeaseMapRaw, LeaseRx, OperationFailureMap, WsTx,
-        config_watcher::watch_config_file, db, host_actor::FullHostEvent, host_actor::HostEventType,
-        host_control::spawn_handle_host_state, shared_watch_store::SharedWatchRx,
+        AppState, HostActorHandle, LeaseMap, LeaseRx, OperationFailureMap, WsTx, config_watcher::watch_config_file, db, host_actor::{FullHostEvent, HostEventType}, host_control::spawn_handle_host_state, notifications::{EventKind, NotificationEvent}, shared_watch_store::SharedWatchRx
     },
     config::{Host, StructuredEventFilter, WebhookEventFilter},
     http::push,
@@ -271,7 +269,7 @@ pub(super) fn start_background_tasks(
     ));
 
     // Consume the HostEvent stream to fire unscheduled push notifications.
-    tasks.spawn(handle_host_events(
+    tasks.spawn(report_unscheduled_events(
         state.host_actor.subscribe_events(),
         state.leases.snapshot(),
         state.db_pool.clone(),
@@ -692,9 +690,9 @@ async fn spawn_push_online_for_timers(
 /// An event is "unscheduled" when:
 /// - `Offline → Online` with no active leases (host booted without coordinator involvement).
 /// - `Online → Offline` while leases are held (host went offline unexpectedly).
-async fn handle_host_events(
+async fn report_unscheduled_events(
     mut events_rx: broadcast::Receiver<FullHostEvent>,
-    initial_leases: Arc<LeaseMapRaw>,
+    initial_leases: Arc<LeaseMap>,
     db_pool: Option<db::DbPool>,
     vapid_key: Option<Arc<ES256KeyPair>>,
     mut leases_rx: LeaseRx,
@@ -726,11 +724,13 @@ async fn handle_host_events(
                     .get(&host_name)
                     .is_some_and(|s| !s.is_empty());
 
+                use HostState as HS;
+
                 let is_unscheduled = match (from, to) {
                     // Host came online without the coordinator waking it.
-                    (HostState::Offline, HostState::Online) => !has_leases,
+                    (HS::Offline, HS::Online) => !has_leases,
                     // Host went offline while the coordinator expected it to stay up.
-                    (HostState::Online, HostState::Offline) => has_leases,
+                    (HS::Online, HS::Offline) => has_leases,
                     _ => false,
                 };
 
@@ -739,19 +739,19 @@ async fn handle_host_events(
                 }
 
                 let notification_event = match to {
-                    HostState::Online => notifications::NotificationEvent {
+                    HS::Online => NotificationEvent {
                         host: host_name.clone(),
-                        kind: notifications::EventKind::Unscheduled {
+                        kind: EventKind::Unscheduled {
                             kind: OperationKind::Startup,
                         },
                     },
-                    HostState::Offline => notifications::NotificationEvent {
+                    HS::Offline => NotificationEvent {
                         host: host_name.clone(),
-                        kind: notifications::EventKind::Unscheduled {
+                        kind: EventKind::Unscheduled {
                             kind: OperationKind::Shutdown,
                         },
                     },
-                    HostState::Waking | HostState::ShuttingDown => continue,
+                    HS::Waking | HS::ShuttingDown => continue,
                 };
 
                 let webhooks = config_rx.borrow().notifications.webhooks.clone();
@@ -774,9 +774,9 @@ async fn handle_host_events(
 /// Background task: watches the lease store and forwards per-host lease changes
 /// into the [`HostActorHandle`] event stream so all consumers can use a single stream.
 async fn forward_lease_events(mut leases_rx: LeaseRx, host_actor: HostActorHandle) {
-    let mut prev_leases: Arc<LeaseMapRaw> = leases_rx.borrow_and_update().clone();
+    let mut prev_leases: Arc<LeaseMap> = leases_rx.borrow_and_update().clone();
     while leases_rx.changed().await.is_ok() {
-        let new_leases: Arc<LeaseMapRaw> = leases_rx.borrow_and_update().clone();
+        let new_leases: Arc<LeaseMap> = leases_rx.borrow_and_update().clone();
         // Notify the actor for each host whose lease set changed.
         let all_hosts: HashSet<&str> = prev_leases
             .keys()

--- a/coordinator/src/app/state.rs
+++ b/coordinator/src/app/state.rs
@@ -15,7 +15,7 @@ use web_push_native::jwt_simple::algorithms::ES256KeyPair;
 use super::shared_watch_store::SharedWatchStore;
 use crate::{
     app::{
-        LeaseMapRaw,
+        LeaseMap,
         db::{self, DbPool},
         host_actor::HostActorHandle,
         host_control::LeaseStore,
@@ -263,7 +263,7 @@ fn emit_startup_warnings(app_state: &AppState, app_config: &ControllerConfig) {
 }
 
 async fn load_leases(db_pool: Option<&DbPool>) -> eyre::Result<Arc<LeaseStore>> {
-    let mut initial_leases = LeaseMapRaw::default();
+    let mut initial_leases = LeaseMap::default();
     if let Some(pool) = db_pool {
         db::load_leases(pool, &mut initial_leases).await?;
         info!("Loaded leases from database");

--- a/coordinator/src/app/state.rs
+++ b/coordinator/src/app/state.rs
@@ -48,9 +48,6 @@ impl HostState {
 
 pub(crate) type ConfigRx = watch::Receiver<Arc<ControllerConfig>>;
 pub(super) type ConfigTx = watch::Sender<Arc<ControllerConfig>>;
-pub type HostStatus = HashMap<String, HostState>;
-/// Alias kept for compatibility with existing watch subscribers.
-pub(crate) type HostStatusRx = watch::Receiver<Arc<HostStatus>>;
 pub(crate) type OperationFailureStore = SharedWatchStore<OperationFailureMap>;
 pub(crate) type WsTx = broadcast::Sender<WsMessage>;
 
@@ -359,7 +356,7 @@ pub(super) async fn initialize_state(
     let initial_config = Arc::new(load(config_path).await?);
 
     let (config_tx, config_rx) = watch::channel(initial_config.clone());
-    let host_actor = HostActorHandle::spawn(HostStatus::new());
+    let host_actor = HostActorHandle::spawn(HashMap::new());
     let (ws_tx, _) = broadcast::channel(32);
     let (operation_failures, _) = OperationFailureStore::new(OperationFailureMap::new());
 

--- a/coordinator/src/app/update_check.rs
+++ b/coordinator/src/app/update_check.rs
@@ -56,6 +56,7 @@ fn needs_update(current: &str, latest_tag: &str) -> Option<bool> {
     let current_str = current_base.strip_prefix('v').unwrap_or(current_base);
 
     let latest = Version::parse(latest_str).ok()?;
+    #[expect(clippy::shadow_unrelated, reason = "false positive")]
     let current = Version::parse(current_str).ok()?;
     Some(latest > current)
 }

--- a/coordinator/src/config/types.rs
+++ b/coordinator/src/config/types.rs
@@ -324,12 +324,13 @@ pub(crate) enum AuthMode {
     Token { token: Option<Arc<SecretString>> },
     /// `OpenID` Connect login via authorization code flow
     Oidc(OidcConfig),
-    /// External auth was configured (reverse proxy / external provider). The
-    /// `exceptions_version` is used to record which set/level of exceptions the
-    /// operator acknowledged; the UI will show a warning when this doesn't
-    /// match the current expected version so operators can update their proxy
-    /// rules.
-    External { exceptions_version: u32 },
+    /// External auth was configured (reverse proxy / external provider).
+    External {
+        /// Records which set/level of exceptions the operator acknowledged;
+        /// the UI will show a warning when this doesn't match the current
+        /// expected version so operators can update their proxy rules.
+        exceptions_version: u32,
+    },
 }
 
 impl PartialEq for AuthMode {

--- a/coordinator/src/demo.rs
+++ b/coordinator/src/demo.rs
@@ -15,7 +15,7 @@ use tracing::info;
 
 use crate::{
     app::{
-        AppState, HostActorHandle, LeaseMapRaw, LeaseStore, OperationFailureStore, RwMap,
+        AppState, HostActorHandle, LeaseMap, LeaseStore, OperationFailureStore, RwMap,
         shutdown_signal,
     },
     config::{AuthConfig, ControllerConfig, RuntimeConfig},
@@ -55,7 +55,7 @@ pub(crate) async fn run_demo_service(port: u16, bind: &str, subpath: &str) {
         config_rx: watch::channel(Arc::new(ControllerConfig::default())).1,
         host_actor: hoststatus,
         ws_tx: broadcast::channel(1).0,
-        leases: LeaseStore::new(LeaseMapRaw::default()).0,
+        leases: LeaseStore::new(LeaseMap::default()).0,
         host_overrides: RwMap::default(),
         host_install_info: RwMap::default(),
         auth: Arc::new(

--- a/coordinator/src/websocket.rs
+++ b/coordinator/src/websocket.rs
@@ -17,7 +17,7 @@ use tracing::{Instrument as _, debug, error, info, warn};
 use tungstenite::{Error as TError, error::ProtocolError as TPError};
 
 use crate::app::{
-    AppState, ConfigRx, DbPool, HostState, HostStatus, HostStatusRx, LeaseMapRaw, LeaseSources,
+    AppState, ConfigRx, DbPool, HostState, HostStatus, HostStatusRx, LeaseMap, LeaseSources,
     LeaseStore, OperationFailureMap,
     db::{self, ClientStats, HostStats},
 };
@@ -74,7 +74,7 @@ pub enum WsMessage {
         hosts: Vec<String>,
         clients: Vec<String>,
         status_map: HostStatus,
-        lease_map: LeaseMapRaw,
+        lease_map: LeaseMap,
         db_data: DbDataState,
         operation_failures: OperationFailureMap,
     },

--- a/host_agent/src/install/mod.rs
+++ b/host_agent/src/install/mod.rs
@@ -70,8 +70,6 @@ pub(crate) fn bind_template_replacements(
         .replace("{ hostname }", hostname)
 }
 
-// TODO: update command needs integration tests
-
 /// Arguments for the `install` subcommand of `host_agent`.
 #[derive(Debug, Parser)]
 pub struct Args {


### PR DESCRIPTION
Switches a lot of observers of lease changes to get their updates from the host_actor instead. Reworks the way unscheduled operations are detected, which in turn should get rid of wrong notifications dispatched by that.